### PR TITLE
🏥 Add "healthcare" influencers to queries and as a possible classification

### DIFF
--- a/twitter_search/config_utils/constants.py
+++ b/twitter_search/config_utils/constants.py
@@ -2,8 +2,10 @@
 This script contains constants used across the project.
 """
 
-from config_utils.queries import QUERIES_EN
 from pathlib import Path
+
+from config_utils.queries import QUERIES_EN
+
 
 # Lists_filtering constants
 

--- a/twitter_search/config_utils/constants.py
+++ b/twitter_search/config_utils/constants.py
@@ -49,7 +49,6 @@ BATCH_SIZE = 8
 
 
 # OTHER CONSTANTS
-
 LIST_FIELDS = ["id", "name", "description"]
 USER_FIELDS = [
     "created_at",
@@ -74,10 +73,11 @@ RELEVANT_LABELS = [
     "politician or policymaker",
     "nonprofit organization",
     "news outlet or journalist",
+    "healthcare professional",
     "other",
 ]
+
 # CONSTANTS FOR SEARCH USERS AND GET LISTS SCRIPTS
-# Dictionary mapping Indian state capitals to their respective states
 MAX_RESULTS = 99
 MAX_TWEETS_FROM_USERS = 5
 MAX_RESULTS_LISTS = 24

--- a/twitter_search/config_utils/constants.py
+++ b/twitter_search/config_utils/constants.py
@@ -2,10 +2,8 @@
 This script contains constants used across the project.
 """
 
-# CONSTANTS FOR THE UTIL SCRIPT
-
+from queries import QUERIES_EN
 from pathlib import Path
-
 
 # Lists_filtering constants
 
@@ -21,8 +19,11 @@ REGION_NAME = "us-west-1"
 RAW_DATA_PATH = project_root / "data" / "raw_data"
 CLEAN_DATA_PATH = project_root / "data" / "cleaned_data"
 
-# RELEVANT USER COLUMNS
+# ACCOUNT TYPES
+ACCOUNT_TYPES = list(QUERIES_EN.keys())
+ACCOUNT_TYPES.append("all")
 
+# RELEVANT USER COLUMNS
 USER_COLUMNS = [
     "user_id",
     "username",
@@ -47,6 +48,16 @@ SCORE_THRESHOLD = 0.4
 NUM_WORKERS = 8
 BATCH_SIZE = 8
 
+# NLP Model Classification Labels
+RELEVANT_LABELS = [
+    "environment or pollution",
+    "environmental research",
+    "politician or policymaker",
+    "nonprofit organization",
+    "news outlet or journalist",
+    "healthcare professional",
+    "other",
+]
 
 # OTHER CONSTANTS
 LIST_FIELDS = ["id", "name", "description"]
@@ -64,17 +75,6 @@ USER_FIELDS = [
     "public_metrics",
     "url",
     "username",
-]
-
-# NLP Model Classification Labels
-RELEVANT_LABELS = [
-    "environment or pollution",
-    "environmental research",
-    "politician or policymaker",
-    "nonprofit organization",
-    "news outlet or journalist",
-    "healthcare professional",
-    "other",
 ]
 
 # CONSTANTS FOR SEARCH USERS AND GET LISTS SCRIPTS
@@ -118,14 +118,10 @@ USER_FIELDS = [
     "username",
 ]
 
-
 # THRESHOLDS FOR GETTING LISTS
 COUNT_THRESHOLD = 240
 SLEEP_TIME = 120
 GEOCODE_TIMEOUT = 5
-
-
-# KEYWORD CONSTANTS
 
 # Creating punctuations to be removed
 PUNCTUATIONS = ["!" "," "." "," '"' "?" ":"]

--- a/twitter_search/config_utils/constants.py
+++ b/twitter_search/config_utils/constants.py
@@ -2,7 +2,7 @@
 This script contains constants used across the project.
 """
 
-from queries import QUERIES_EN
+from config_utils.queries import QUERIES_EN
 from pathlib import Path
 
 # Lists_filtering constants

--- a/twitter_search/config_utils/constants.py
+++ b/twitter_search/config_utils/constants.py
@@ -134,3 +134,4 @@ for char in PUNCTUATIONS:
 # Twikit Constants
 TWIKIT_COOKIES_DIR = "twitter_search/config_utils/cookies.json"
 TWIKIT_THRESHOLD = 50
+SINGLE_ACCOUNT_THRESHOLD = 10

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -19,10 +19,10 @@ QUERIES_EN = {
     "researcher": """location ((environmental research) OR (environmental researcher)
                     OR science OR academic OR research OR university OR professor OR
                     postdoc OR postdoctoral OR PhD) -is:retweet""",
-    "environment": """location ((air pollution) OR pollution OR (poor air) 
+    "environment": """location ((air pollution) OR pollution OR (poor air)
                     OR asthma OR polluted OR (pollution control board)
                     OR smog OR (air quality)) -is:retweet""",
-        "healthcare": """location ((MD OR doctor OR physician OR surgeon OR cardiologist OR pulmonologist
+    "healthcare": """location ((MD OR doctor OR physician OR surgeon OR cardiologist OR pulmonologist
                         OR pediatrician OR nurse OR (healthcare professional) OR (medical expert) OR therapist
                         OR clinician OR specialist OR pharmacist OR pulmonologist OR (medical practitioner)
                         OR (health influencer) OR (board-certified) OR (medical doctor) OR (resident physician))
@@ -48,25 +48,25 @@ QUERIES_ES = {
                     OR (investigadora ambiental) OR ciencia OR academico
                     OR academica OR investigacion OR universidad OR profesor
                     OR postdoc OR postdoctoral OR PhD OR doctorado OR investigador
-                    OR investigadora OR universitario OR universitaria) 
+                    OR investigadora OR universitario OR universitaria)
                     -is:retweet""",
     "environment": """location ((contaminacion del aire) OR contaminacion OR
                     (salud publica) OR (poor air) OR asma OR contaminado OR contaminada
                     OR smog OR (calidad del aire) OR (medio ambiente)) (near: location)
                     -is:retweet""",
-    "healthcare": """location ((MD OR doctor OR doctora OR médico OR médica OR cirujano OR cirujana OR cardiólogo 
-                    OR cardióloga OR neumólogo OR neumóloga OR pediatra OR enfermera OR enfermero 
+    "healthcare": """location ((MD OR doctor OR doctora OR médico OR médica OR cirujano OR cirujana OR cardiólogo
+                    OR cardióloga OR neumólogo OR neumóloga OR pediatra OR enfermera OR enfermero
                     OR (profesional de la salud) OR terapeuta OR clínico OR clínica OR especialista
                     OR farmacéutico OR neumólogo OR (practicante médico) OR (influencer de salud) OR certificado
                     OR certificada OR (médico residente))
-                    -is:retweet"""
+                    -is:retweet""",
 }
 
 
 QUERIES_FR = {
     "media": """location (média OR presse OR couverture OR diffusion
                 OR (flash info) OR journalisme OR journaliste
-                OR local OR actualités) 
+                OR local OR actualités)
                 -is:retweet""",
     "organizations": """((ONG location) OR (organisation location)
                        OR (non lucratif location) OR (location institution) OR

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -19,9 +19,14 @@ QUERIES = {
     "researcher": """location ((environmental research) OR (environmental researcher)
                     OR science OR academic OR research OR university OR professor OR
                     postdoc OR postdoctoral OR PhD) -is:retweet""",
-    "environment": """location ((air pollution) OR pollution OR (public health)
-                OR (poor air) OR asthma OR polluted OR (pollution control board)
-                OR smog OR (air quality)) -is:retweet""",
+    "environment": """location ((air pollution) OR pollution OR (poor air) 
+                    OR asthma OR polluted OR (pollution control board)
+                    OR smog OR (air quality)) -is:retweet""",
+        "healthcare": """location ((MD OR doctor OR physician OR surgeon OR cardiologist OR pulmonologist
+                        OR pediatrician OR nurse OR (healthcare professional) OR (medical expert) OR therapist
+                        OR clinician OR specialist OR pharmacist OR pulmonologist OR (medical practitioner)
+                        OR (health influencer) OR (board-certified) OR (medical doctor) OR (resident physician))
+                        -is:retweet""",
 }
 
 
@@ -49,6 +54,12 @@ QUERIES_ES = {
                     (salud publica) OR (poor air) OR asma OR contaminado OR contaminada
                     OR smog OR (calidad del aire) OR (medio ambiente)) (near: location)
                     -is:retweet""",
+    "healthcare": """location ((MD OR doctor OR doctora OR médico OR médica OR cirujano OR cirujana OR cardiólogo 
+                    OR cardióloga OR neumólogo OR neumóloga OR pediatra OR enfermera OR enfermero 
+                    OR (profesional de la salud) OR terapeuta OR clínico OR clínica OR especialista
+                    OR farmacéutico OR neumólogo OR (practicante médico) OR (influencer de salud) OR certificado
+                    OR certificada OR (médico residente))
+                    -is:retweet"""
 }
 
 
@@ -75,6 +86,11 @@ QUERIES_FR = {
     "environment": """location ((pollution de l'air) OR pollution OR (santé publique)
                 OR (air de mauvaise qualité) OR asthme OR pollué OR (commission de contrôle de la pollution)
                 OR smog OR (qualité de l'air)) -is:retweet""",
+    "healthcare": """((MD OR médecin OR docteur OR docteure OR chirurgien OR chirurgienne OR cardiologue
+                OR pneumologue OR pédiatre OR infirmier OR infirmière OR (professionnel de santé) OR thérapeute
+                OR clinicien OR clinicienne OR spécialiste OR pharmacien OR pharmacie OR (praticien médical)
+                OR (influenceur santé) OR (certifié OR certifiée) OR (médecin résident))
+                -is:retweet""",
 }
 
 

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -29,50 +29,54 @@ QUERIES = {
 QUERIES_ES = {
     "media": """location (media OR prensa OR periodico OR transmision
                           OR periodismo OR periodista
-                          OR local OR noticias) -is:retweet""",
+                          OR local OR noticias) (near: location) -is:retweet""",
     "organizations": """location ("NGO" OR "organizacion" OR "organizaciones" OR
                      "organizacion civil" OR "non-profit" OR "institucion" OR
                      "sin fines de lucro" OR "non-governmental organization" OR
-                     "nonprofit") -is:retweet""",
+                     "nonprofit") (near: location) -is:retweet""",
     "policymaker": """location (gobernador OR ministro OR magistrado OR diputado
                     OR senador OR gabinete OR (gobierno local) OR gobierno OR
                     municipio OR delegacion OR ministerio OR legislador OR legisladores
-                    OR legislacion OR legisladora)
+                    OR legislacion OR legisladora) (near: location)
                     -is:retweet""",
-    "politicians": """location (politica OR politicos OR politico OR politicas)
+    "politicians": """location (politica OR politicos OR politico OR politicas) (near: location)
                       -is:retweet""",
     "researcher": """location ((investigacion ambiental) OR (investigador ambiental)
                     OR (investigadora ambiental) OR ciencia OR academico
                     OR academica OR investigacion OR universidad OR profesor
                     OR postdoc OR postdoctoral OR PhD OR doctorado OR investigador
-                    OR investigadora OR universitario OR universitaria) -is:retweet""",
+                    OR investigadora OR universitario OR universitaria) (near: location) 
+                    -is:retweet""",
     "environment": """location ((contaminacion del aire) OR contaminacion OR
                     (salud publica) OR (poor air) OR asma OR contaminado OR contaminada
-                    OR smog OR (calidad del aire) OR (medio ambiente)) -is:retweet""",
+                    OR smog OR (calidad del aire) OR (medio ambiente)) (near: location)
+                    -is:retweet""",
 }
 
 
 QUERIES_FR = {
     "media": """location (média OR presse OR couverture OR diffusion
                 OR (flash info) OR journalisme OR journaliste
-                OR local OR actualités) -is:retweet""",
+                OR local OR actualités) (near: location) 
+                -is:retweet""",
     "organizations": """((ONG location) OR (organisation location)
                        OR (non lucratif location) OR (location institution) OR
                        (organisation non gouvernementale location) OR (non lucratif location))
-                       -is:retweet""",
+                       (near: location) -is:retweet""",
     "policymaker": """location ((membre du parlement) OR gouverneur OR ministre
                     OR magistrat OR (magistrat de district) OR IAS OR officier
                     OR cabinet OR maire OR conseiller municipal OR (gouvernement local)
                     OR (fonctionnaire municipal) OR (MLA) OR (député) OR gouvernement OR municipalité)
-                    -is:retweet""",
-    "politicians": """location (politique OR politiciens OR politicien) -is:retweet""",
+                    (near: location) -is:retweet""",
+    "politicians": """location (politique OR politiciens OR politicien) (near: location)
+                      -is:retweet""",
     "researcher": """location ((recherche environnementale) OR (chercheur environnemental)
                     OR science OR universitaire OR recherche OR université OR professeur OR
-                    postdoc OR postdoctoral OR doctorat)
+                    postdoc OR postdoctoral OR doctorat) (near: location)
                     -is:retweet""",
     "environment": """location ((pollution de l'air) OR pollution OR (santé publique)
                 OR (air de mauvaise qualité) OR asthme OR pollué OR (commission de contrôle de la pollution)
-                OR smog OR (qualité de l'air)) -is:retweet""",
+                OR smog OR (qualité de l'air)) (near: location) -is:retweet""",
 }
 
 

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -36,8 +36,7 @@ QUERIES_ES = {
     "policymaker": """location (gobernador OR ministro OR magistrado OR diputado
                     OR senador OR gabinete OR (gobierno local) OR gobierno OR
                     municipio OR delegacion OR ministerio OR legislador OR legisladores
-                    OR legislacion OR legisladora) (near: location)
-                    -is:retweet""",
+                    OR legislacion OR legisladora) -is:retweet""",
     "politicians": """location (politica OR politicos OR politico OR politicas) (near: location)
                       -is:retweet""",
     "researcher": """location ((investigacion ambiental) OR (investigador ambiental)

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -5,24 +5,24 @@ Dictionary with the current queries for searching users
 QUERIES = {
     "media": """location (media OR press OR coverage OR broadcasting
                 OR (breaking news) OR journalism OR journalist
-                OR local OR news) -is:retweet""",
+                OR local OR news) (near: location) -is:retweet""",
     "organizations": """((NGO location) OR (organization location)
                        OR (non-profit location) OR (location institution) OR
                        (non-governmental organization location) OR (nonprofit location))
-                       -is:retweet""",
+                       (near: location) (near: location) -is:retweet""",
     "policymaker": """location ((member of parliament) OR governor OR minister
                     OR magistrate OR (district magistrate) OR IAS OR officer
                     OR cabinet OR mayor OR councillor OR (local government)
                     OR (city official) OR (MLA) OR (MP) OR government OR municipality)
-                    -is:retweet""",
+                    (near: location) -is:retweet""",
     "politicians": """location (politics OR politicians OR politician) -is:retweet""",
     "researcher": """location ((environmental research) OR (environmental researcher)
                     OR science OR academic OR research OR university OR professor OR
-                    postdoc OR postdoctoral OR PhD)
+                    postdoc OR postdoctoral OR PhD) (near: location)
                     -is:retweet""",
     "environment": """location ((air pollution) OR pollution OR (public health)
                 OR (poor air) OR asthma OR polluted OR (pollution control board)
-                OR smog OR (air quality)) -is:retweet""",
+                OR smog OR (air quality)) (near: location) -is:retweet""",
 }
 
 

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -42,7 +42,7 @@ QUERIES_ES = {
                     OR senador OR gabinete OR (gobierno local) OR gobierno OR
                     municipio OR delegacion OR ministerio OR legislador OR legisladores
                     OR legislacion OR legisladora) -is:retweet""",
-    "politicians": """location (politica OR politicos OR politico OR politicas) (near: location)
+    "politicians": """location (politica OR politicos OR politico OR politicas)
                       -is:retweet""",
     "researcher": """location ((investigacion ambiental) OR (investigador ambiental)
                     OR (investigadora ambiental) OR ciencia OR academico
@@ -52,7 +52,7 @@ QUERIES_ES = {
                     -is:retweet""",
     "environment": """location ((contaminacion del aire) OR contaminacion OR
                     (salud publica) OR (poor air) OR asma OR contaminado OR contaminada
-                    OR smog OR (calidad del aire) OR (medio ambiente)) (near: location)
+                    OR smog OR (calidad del aire) OR (medio ambiente))
                     -is:retweet""",
     "healthcare": """location ((MD OR doctor OR doctora OR médico OR médica OR cirujano OR cirujana OR cardiólogo
                     OR cardióloga OR neumólogo OR neumóloga OR pediatra OR enfermera OR enfermero
@@ -77,11 +77,11 @@ QUERIES_FR = {
                     OR cabinet OR maire OR conseiller municipal OR (gouvernement local)
                     OR (fonctionnaire municipal) OR (MLA) OR (député) OR gouvernement OR municipalité)
                     -is:retweet""",
-    "politicians": """location (politique OR politiciens OR politicien) (near: location)
+    "politicians": """location (politique OR politiciens OR politicien)
                       -is:retweet""",
     "researcher": """location ((recherche environnementale) OR (chercheur environnemental)
                     OR science OR universitaire OR recherche OR université OR professeur OR
-                    postdoc OR postdoctoral OR doctorat) (near: location)
+                    postdoc OR postdoctoral OR doctorat)
                     -is:retweet""",
     "environment": """location ((pollution de l'air) OR pollution OR (santé publique)
                 OR (air de mauvaise qualité) OR asthme OR pollué OR (commission de contrôle de la pollution)

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -2,7 +2,7 @@
 Dictionary with the current queries for searching users
 """
 # QUERY DICTIONARY
-QUERIES = {
+QUERIES_EN = {
     "media": """location (media OR press OR coverage OR broadcasting
                 OR (breaking news) OR journalism OR journalist
                 OR local OR news) -is:retweet""",
@@ -94,4 +94,4 @@ QUERIES_FR = {
 }
 
 
-QUERIES_DICT = {"en": QUERIES, "es": QUERIES_ES, "fr": QUERIES_FR}
+QUERIES_DICT = {"en": QUERIES_EN, "es": QUERIES_ES, "fr": QUERIES_FR}

--- a/twitter_search/config_utils/queries.py
+++ b/twitter_search/config_utils/queries.py
@@ -5,35 +5,34 @@ Dictionary with the current queries for searching users
 QUERIES = {
     "media": """location (media OR press OR coverage OR broadcasting
                 OR (breaking news) OR journalism OR journalist
-                OR local OR news) (near: location) -is:retweet""",
+                OR local OR news) -is:retweet""",
     "organizations": """((NGO location) OR (organization location)
                        OR (non-profit location) OR (location institution) OR
                        (non-governmental organization location) OR (nonprofit location))
-                       (near: location) (near: location) -is:retweet""",
+                       -is:retweet""",
     "policymaker": """location ((member of parliament) OR governor OR minister
                     OR magistrate OR (district magistrate) OR IAS OR officer
                     OR cabinet OR mayor OR councillor OR (local government)
                     OR (city official) OR (MLA) OR (MP) OR government OR municipality)
-                    (near: location) -is:retweet""",
+                    -is:retweet""",
     "politicians": """location (politics OR politicians OR politician) -is:retweet""",
     "researcher": """location ((environmental research) OR (environmental researcher)
                     OR science OR academic OR research OR university OR professor OR
-                    postdoc OR postdoctoral OR PhD) (near: location)
-                    -is:retweet""",
+                    postdoc OR postdoctoral OR PhD) -is:retweet""",
     "environment": """location ((air pollution) OR pollution OR (public health)
                 OR (poor air) OR asthma OR polluted OR (pollution control board)
-                OR smog OR (air quality)) (near: location) -is:retweet""",
+                OR smog OR (air quality)) -is:retweet""",
 }
 
 
 QUERIES_ES = {
     "media": """location (media OR prensa OR periodico OR transmision
                           OR periodismo OR periodista
-                          OR local OR noticias) (near: location) -is:retweet""",
+                          OR local OR noticias) -is:retweet""",
     "organizations": """location ("NGO" OR "organizacion" OR "organizaciones" OR
                      "organizacion civil" OR "non-profit" OR "institucion" OR
                      "sin fines de lucro" OR "non-governmental organization" OR
-                     "nonprofit") (near: location) -is:retweet""",
+                     "nonprofit") -is:retweet""",
     "policymaker": """location (gobernador OR ministro OR magistrado OR diputado
                     OR senador OR gabinete OR (gobierno local) OR gobierno OR
                     municipio OR delegacion OR ministerio OR legislador OR legisladores
@@ -45,7 +44,7 @@ QUERIES_ES = {
                     OR (investigadora ambiental) OR ciencia OR academico
                     OR academica OR investigacion OR universidad OR profesor
                     OR postdoc OR postdoctoral OR PhD OR doctorado OR investigador
-                    OR investigadora OR universitario OR universitaria) (near: location) 
+                    OR investigadora OR universitario OR universitaria) 
                     -is:retweet""",
     "environment": """location ((contaminacion del aire) OR contaminacion OR
                     (salud publica) OR (poor air) OR asma OR contaminado OR contaminada
@@ -57,17 +56,17 @@ QUERIES_ES = {
 QUERIES_FR = {
     "media": """location (média OR presse OR couverture OR diffusion
                 OR (flash info) OR journalisme OR journaliste
-                OR local OR actualités) (near: location) 
+                OR local OR actualités) 
                 -is:retweet""",
     "organizations": """((ONG location) OR (organisation location)
                        OR (non lucratif location) OR (location institution) OR
                        (organisation non gouvernementale location) OR (non lucratif location))
-                       (near: location) -is:retweet""",
+                       -is:retweet""",
     "policymaker": """location ((membre du parlement) OR gouverneur OR ministre
                     OR magistrat OR (magistrat de district) OR IAS OR officier
                     OR cabinet OR maire OR conseiller municipal OR (gouvernement local)
                     OR (fonctionnaire municipal) OR (MLA) OR (député) OR gouvernement OR municipalité)
-                    (near: location) -is:retweet""",
+                    -is:retweet""",
     "politicians": """location (politique OR politiciens OR politicien) (near: location)
                       -is:retweet""",
     "researcher": """location ((recherche environnementale) OR (chercheur environnemental)
@@ -76,7 +75,7 @@ QUERIES_FR = {
                     -is:retweet""",
     "environment": """location ((pollution de l'air) OR pollution OR (santé publique)
                 OR (air de mauvaise qualité) OR asthme OR pollué OR (commission de contrôle de la pollution)
-                OR smog OR (qualité de l'air)) (near: location) -is:retweet""",
+                OR smog OR (qualité de l'air)) -is:retweet""",
 }
 
 

--- a/twitter_search/etl/lists_handler.py
+++ b/twitter_search/etl/lists_handler.py
@@ -7,7 +7,7 @@ This script runs the Twitter search, data collection and filtering process.
 from pathlib import Path
 
 from config_utils.cities import CITIES
-from config_utils.queries import QUERIES
+from config_utils.queries import QUERIES_EN
 from etl.data_collection.get_lists import ListGetter
 from etl.data_collection.get_users import UserGetter
 from twitter_filtering.lists_filtering.filter_lists import (
@@ -22,7 +22,7 @@ class ListsHandler:
     This class handles the Twitter search and data collection process.
     """
 
-    QUERIES = QUERIES
+    QUERIES = QUERIES_EN
     CITIES = CITIES
 
     def __init__(

--- a/twitter_search/etl/twitter_data_handler.py
+++ b/twitter_search/etl/twitter_data_handler.py
@@ -7,7 +7,7 @@ This script runs the Twitter search, data collection and filtering process.
 from pathlib import Path
 
 from config_utils.cities import ALIAS_DICT, CITIES, PILOT_CITIES
-from config_utils.queries import QUERIES
+from config_utils.queries import QUERIES_EN
 from etl.data_collection.get_extra_tweets import TweetGetter
 from etl.data_collection.search_users import UserSearcher
 from etl.data_collection.tweet_processor import TweetProcessor
@@ -20,7 +20,7 @@ class TwitterDataHandler:
     This class handles the Twitter search and data collection process.
     """
 
-    QUERIES = QUERIES
+    QUERIES = QUERIES_EN
     CITIES = CITIES
 
     def __init__(

--- a/twitter_search/run.py
+++ b/twitter_search/run.py
@@ -5,6 +5,7 @@ Main function to run the Twitter search and data collection process.
 from argparse import ArgumentParser
 
 from config_utils.cities import CITIES, PILOT_CITIES
+from config_utils.constants import ACCOUNT_TYPES
 from config_utils.util import strtobool
 
 # Local imports
@@ -28,15 +29,7 @@ def main():
         type=str,
         help="type of accounts that you want\
               [media,organizations,policymaker,politicians,researcher,environment,all]",
-        choices=[
-            "media",
-            "organizations",
-            "policymaker",
-            "politicians",
-            "researcher",
-            "environment",
-            "all",
-        ],
+        choices=ACCOUNT_TYPES,
     )
 
     parser.add_argument(

--- a/twitter_search/run_twikit.py
+++ b/twitter_search/run_twikit.py
@@ -6,7 +6,7 @@ using the Twikit Library
 from argparse import ArgumentParser
 
 from config_utils.cities import CITIES, PILOT_CITIES
-from config_utils.constants import ACCOUNT_TYPES, TWIKIT_THRESHOLD
+from config_utils.constants import ACCOUNT_TYPES, TWIKIT_THRESHOLD, SINGLE_ACCOUNT_THRESHOLD
 from config_utils.util import strtobool
 
 # Local imports
@@ -81,7 +81,7 @@ def main():
             csv_converter = CSVConverter(args.location, twikit=True)
             csv_converter.run()
     else:
-        twikit_data_handler.run()
+        twikit_data_handler.run(SINGLE_ACCOUNT_THRESHOLD)
 
 
 if __name__ == "__main__":

--- a/twitter_search/run_twikit.py
+++ b/twitter_search/run_twikit.py
@@ -6,7 +6,7 @@ using the Twikit Library
 from argparse import ArgumentParser
 
 from config_utils.cities import CITIES, PILOT_CITIES
-from config_utils.constants import TWIKIT_THRESHOLD, ACCOUNT_TYPES
+from config_utils.constants import ACCOUNT_TYPES, TWIKIT_THRESHOLD
 from config_utils.util import strtobool
 
 # Local imports

--- a/twitter_search/run_twikit.py
+++ b/twitter_search/run_twikit.py
@@ -6,7 +6,11 @@ using the Twikit Library
 from argparse import ArgumentParser
 
 from config_utils.cities import CITIES, PILOT_CITIES
-from config_utils.constants import ACCOUNT_TYPES, TWIKIT_THRESHOLD, SINGLE_ACCOUNT_THRESHOLD
+from config_utils.constants import (
+    ACCOUNT_TYPES,
+    SINGLE_ACCOUNT_THRESHOLD,
+    TWIKIT_THRESHOLD,
+)
 from config_utils.util import strtobool
 
 # Local imports

--- a/twitter_search/run_twikit.py
+++ b/twitter_search/run_twikit.py
@@ -6,7 +6,7 @@ using the Twikit Library
 from argparse import ArgumentParser
 
 from config_utils.cities import CITIES, PILOT_CITIES
-from config_utils.constants import TWIKIT_THRESHOLD
+from config_utils.constants import TWIKIT_THRESHOLD, ACCOUNT_TYPES
 from config_utils.util import strtobool
 
 # Local imports
@@ -28,17 +28,8 @@ def main():
     parser.add_argument(
         "account_type",
         type=str,
-        help="type of accounts that you want\
-              [media,organizations,policymaker,politicians,researcher,environment,all]",
-        choices=[
-            "media",
-            "organizations",
-            "policymaker",
-            "politicians",
-            "researcher",
-            "environment",
-            "all",
-        ],
+        help="Desired account type to look users for",
+        choices=ACCOUNT_TYPES,
     )
 
     parser.add_argument(

--- a/twitter_search/twikit_etl/twikit_data_handler.py
+++ b/twitter_search/twikit_etl/twikit_data_handler.py
@@ -76,7 +76,7 @@ class TwikitDataHandler:
 
         Args:
             city_requests: int determining the number of requests per city
-        """
+        """        
         account_requests = city_requests / self.num_accounts
         remainder_requests = city_requests % self.num_accounts
 
@@ -215,10 +215,9 @@ class TwikitDataHandler:
             if "media" in account_types:
                 del account_types["media"]
                 # Number of account types
-                self.num_accounts = len(self.QUERIES) - 1
+                self.num_accounts = len(account_types)
 
         accounts_requests = self.get_account_num_requests(city_requests)
-        print(accounts_requests)
 
         for account_type, account_requests in zip(
             account_types, accounts_requests

--- a/twitter_search/twikit_etl/twikit_data_handler.py
+++ b/twitter_search/twikit_etl/twikit_data_handler.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytz
 from config_utils.cities import ALIAS_DICT, CITIES, PILOT_CITIES
 from config_utils.constants import TWIKIT_THRESHOLD
-from config_utils.queries import QUERIES
+from config_utils.queries import QUERIES_EN
 from etl.query import Query
 from twikit_etl.data_collection.search_twikit_users import TwikitUserSearcher
 from twitter_filtering.users_filtering.filter_users import UserFilter
@@ -19,7 +19,7 @@ class TwikitDataHandler:
     Class that handles the Twikit search and data collection process
     """
 
-    QUERIES = QUERIES
+    QUERIES = QUERIES_EN
     CITIES = CITIES
     PILOT_CITIES = PILOT_CITIES
     TWIKIT_THRESHOLD = TWIKIT_THRESHOLD

--- a/twitter_search/twikit_etl/twikit_data_handler.py
+++ b/twitter_search/twikit_etl/twikit_data_handler.py
@@ -76,7 +76,7 @@ class TwikitDataHandler:
 
         Args:
             city_requests: int determining the number of requests per city
-        """        
+        """
         account_requests = city_requests / self.num_accounts
         remainder_requests = city_requests % self.num_accounts
 


### PR DESCRIPTION
- Added the "healthcare" queries to identify healthcare professionals
- Added "healthcare professionals" as a possible label the model can choose from
- `ACCOUNT_TYPES` is now in constants and is calculated from the number of keys in the `QUERIES_EN` file
- When looking for a single type of account, we lower the limit to 10 requests